### PR TITLE
Fix comment highlighting

### DIFF
--- a/syntaxes/Velocity.tmLanguage
+++ b/syntaxes/Velocity.tmLanguage
@@ -63,7 +63,7 @@
 			<key>match</key>
 			<string>(\#\#).*$\n?</string>
 			<key>name</key>
-			<string>source.velocity.embedded</string>
+			<string>comment.line</string>
 		</dict>
 		<dict>
 			<key>begin</key>


### PR DESCRIPTION
I noticed that the comment highlighting for single line comments (starting with a ##) does not work. The reason was that the scope name was  not changed.